### PR TITLE
feat: add support for rubocop-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,9 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in rubocop-safe_todo_searcher.gemspec
 gemspec
-
-gem "rake", "~> 13.0"
-
-gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.21"

--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -14,7 +14,7 @@ module Rubocop
       rescue StandardError
         nil
       end
-      print res
+      res
     end
   end
 end

--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -1,4 +1,5 @@
 require "rubocop"
+require "rubocop-rails"
 require "yaml"
 require_relative "safe_todo_searcher/version"
 

--- a/rubocop-safe_todo_searcher.gemspec
+++ b/rubocop-safe_todo_searcher.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.6.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/ydah/rubocop-safe_todo_searcherß"
+  spec.metadata["source_code_uri"] = "https://github.com/ydah/rubocop-safe_todo_searcher"
   spec.metadata["changelog_uri"] = "https://github.com/ydah/rubocop-safe_todo_searcher/blob/main/CHANGELOG.md"
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do

--- a/rubocop-safe_todo_searcher.gemspec
+++ b/rubocop-safe_todo_searcher.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "rubocop", "~> 1.21"
+  spec.add_dependency "rubocop-rails"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end

--- a/rubocop-safe_todo_searcher.gemspec
+++ b/rubocop-safe_todo_searcher.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = "https://github.com/ydah/rubocop-safe_todo_searcherß"
   spec.metadata["changelog_uri"] = "https://github.com/ydah/rubocop-safe_todo_searcher/blob/main/CHANGELOG.md"
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject do |f|
       (f == __FILE__) || f.match(%r{\A(?:(?:test|spec|features)/|\.(?:git|travis|circleci)|appveyor)})
@@ -29,9 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
-
-  # For more information and examples about making a new gem, checkout our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  spec.add_dependency "rubocop", "~> 1.21"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
- Added support for `rubocop-rails`
- Refactored unnecessary processes
- Moved dependencies from Gemfile to gemspec
- Fixed typos in URLs in gemspec