### PR TITLE
Fix missing file error

### DIFF
--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -7,15 +7,16 @@ module Rubocop
   module SafeTodoSearcher
     class Error < StandardError; end
 
+    @result = ""
+
     def self.search
       if File.exist?(".rubocop_todo.yml")
-        res = ""
         open(".rubocop_todo.yml", "r") { |f| YAML.safe_load(f) }.each_key do |key|
-          res << "#{key}\n" if support_autocorrect?(key)
+          @result << "#{key}\n" if support_autocorrect?(key)
         rescue StandardError
           nil
         end
-        res
+        @result
       else
         "rubocop_todo.yml does not exist"
       end

--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -11,8 +11,7 @@ module Rubocop
       if File.exist?(".rubocop_todo.yml")
         res = ""
         open(".rubocop_todo.yml", "r") { |f| YAML.safe_load(f) }.each_key do |key|
-          klass = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
-          res << "#{key}\n" if klass.support_autocorrect?
+          res << "#{key}\n" if support_autocorrect?(key)
         rescue StandardError
           nil
         end
@@ -20,6 +19,11 @@ module Rubocop
       else
         "rubocop_todo.yml does not exist"
       end
+    end
+
+    def self.support_autocorrect?(key)
+      klass = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
+      klass.support_autocorrect?
     end
   end
 end

--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -8,14 +8,16 @@ module Rubocop
     class Error < StandardError; end
 
     def self.search
-      res = ""
-      open(".rubocop_todo.yml", "r") { |f| YAML.safe_load(f) }.each_key do |key|
-        klass = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
-        res << "#{key}\n" if klass.support_autocorrect?
-      rescue StandardError
-        nil
+      if File.exist?(".rubocop_todo.yml")
+        res = ""
+        open(".rubocop_todo.yml", "r") { |f| YAML.safe_load(f) }.each_key do |key|
+          klass = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
+          res << "#{key}\n" if klass.support_autocorrect?
+        rescue StandardError
+          nil
+        end
+        res
       end
-      res
     end
   end
 end

--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -17,6 +17,8 @@ module Rubocop
           nil
         end
         res
+      else
+        "rubocop_todo.yml does not exist"
       end
     end
   end


### PR DESCRIPTION
Fix #7 : missing file error

- Fix to not search rubocop_todo.yml if it doesn't exist
- Fix rubocop_todo.yml to output an error message if it doesn't exist
- Create method self.support_autocorrect?
- Change the result to an instance variable