### PR TITLE
[Fix #15] Fixes to detect Unsafe cops

### DIFF
--- a/lib/rubocop/safe_todo_searcher.rb
+++ b/lib/rubocop/safe_todo_searcher.rb
@@ -22,8 +22,8 @@ module Rubocop
     end
 
     def self.support_autocorrect?(key)
-      klass = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
-      klass.support_autocorrect?
+      cop = Object.const_get "RuboCop::Cop::#{key.gsub(%r{/}, "::")}"
+      cop.support_autocorrect? && cop.new(RuboCop::ConfigLoader.default_configuration).safe_autocorrect?
     rescue NameError
       false
     end

--- a/spec/rubocop/safe_todo_searcher_spec.rb
+++ b/spec/rubocop/safe_todo_searcher_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe Rubocop::SafeTodoSearcher do
         expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Lint/AmbiguousOperatorPrecedence")).to be true
         expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Migration/DepartmentName")).to be true
         expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Naming/BinaryOperatorParameterName")).to be true
-        expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Security/YAMLLoad")).to be true
         expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Style/AccessorGrouping")).to be true
         expect(Rubocop::SafeTodoSearcher.support_autocorrect?("Rails/ActionFilter")).to be true
       end


### PR DESCRIPTION
Fixes #15.

This PR fixes to detect "Unsafe" cops.

For example, Security/YAMLLoad is supported auto-correct but Unsafe cops.
This cop should not be analogized as a safe cop.

If there is an unsafe cop, it will not be detected.